### PR TITLE
sort software index, add opendoas and alsa-utils

### DIFF
--- a/index.txt
+++ b/index.txt
@@ -83,11 +83,12 @@
 |                                                                              |
 | SOFTWARE                                                                     |
 |                                                                              |
-|  @/software/git                           @/software/openssh                 |
-|  @/software/wpa_supplicant                @/software/dhcpcd                  |
-|  @/software/eiwd                          @/software/tzdata                  |
-|  @/software/vim                           @/software/man-pages               |
-|  @/software/acpid                                                            |
+|  @/software/acpid                         @/software/opendoas                |
+|  @/software/alsa-utils                    @/software/openssh                 |
+|  @/software/dhcpcd                        @/software/tzdata                  |
+|  @/software/eiwd                          @/software/vim                     |
+|  @/software/git                           @/software/wpa-supplicant          |
+|  @/software/man-pages                                                        |
 |                                                                              |
 +------------------------------------------------------------------------------+
 


### PR DESCRIPTION
Sorted the software index alphabetically, and added indices for two pages (opendoas and alsa-utils).
Not sure why it wasn't sorted before, or why those pages weren't indexed, but if there's a reason then ignore this.