### PR TITLE
replacing-udev: update with instructions for libudev-zero

### DIFF
--- a/dev/replacing-udev.txt
+++ b/dev/replacing-udev.txt
@@ -96,6 +96,7 @@ ________________________________________________________________________________
   Alternatively, the uevent helper path can be set by the init system.
 
   # echo "/bin/echo /usr/bin/uevent-helper <dir> > /proc/sys/kernel/hotplug"
+  #     > /etc/rc.d/uevent-helper.boot
 
   Replace <dir> with the path where you want the uevent files to be stored, or
   leave it empty to use the default path.

--- a/dev/replacing-udev.txt
+++ b/dev/replacing-udev.txt
@@ -1,17 +1,10 @@
 REPLACING UDEV
 ________________________________________________________________________________
 
-As of the 20/01/2020, it is now possible to replace eudev with the device
-manager of your choosing. This Wiki page will cover replacing eudev with
-busybox mdev, however the steps are more or less the same for all other device
-managers (smdev, vdev, ...).
-
-
-CAVEATS
-________________________________________________________________________________
-
-- Xorg will be unable to automatically detect input devices.
-- Libinput will be unable to use its quirks system.
+As of the 20/01/2020, it is now possible to replace eudev with libudev-zero and
+the device manager of your choosing. This Wiki page will cover replacing eudev
+with busybox mdev, however the steps are more or less the same for all other
+device managers (smdev, vdev, ...).
 
 
 BENEFITS
@@ -22,126 +15,12 @@ ________________________________________________________________________________
 - Faster boot process.
 
 
-PREPARATION
-________________________________________________________________________________
-
-1. Make note of your current XKB rules, model and layout.
-
-   Xorg compiled without eudev may require manual configuration to correctly set
-   the keyboard's layout and other settings. The following command can be used
-   to detect the current configuration from a working machine.
-
-       $ setxkbmap -query
-         rules:      evdev
-         model:      pc105
-         layout:     us
-
-2. Make note of your keyboard and mouse's /dev/input/event* entries.
-
-   We also need to point Xorg to the input device's device entries in
-   /dev/input. The following command lists all current input devices.
-
-       $ xinput
-       | Virtual core pointer                id=2    [master pointer  (3)]
-       |   | Virtual core XTEST pointer      id=4    [slave  pointer  (2)]
-       |   | touchpad0                       id=6    [slave  pointer  (2)]
-       | Virtual core keyboard               id=3    [master keyboard (2)]
-           | Virtual core XTEST keyboard     id=5    [slave  keyboard (3)]
-           | keyboard0                       id=7    [slave  keyboard (3)]
-
-
-   My keyboard has the ID '7'. The following command prints its information
-   including the needed device node location.
-
-       $ xinput --list-props 7
-       Device 'keyboard0':
-       Device Enabled (169):   1
-       libinput Send Events Modes Available (316):     1, 0
-       libinput Send Events Mode Enabled (317):        0, 0
-       libinput Send Events Mode Enabled Default (318):        0, 0
-       Device Node (319):      "/dev/input/event4"
-       Device Product ID (320):        1, 1
-
-
-   The "Device Node (XXX):" line displays the location in /dev/ of my keyboard
-   and is the value we will use when configuring Xorg. My keyboard is located
-   at /dev/input/event4. This command should be repeated for any other input
-   devices.
-
-
-CONFIGURING XORG
-________________________________________________________________________________
-
-When Xorg is built without eudev, Xorg will be unable to automatically find and
-use input devices. This requires the use of a "static" configuration using
-.conf files.
-
-NOTE: For this example I am configuring a touchpad alongside the
-      keyboard. The 10-touchpad.conf file should be 1:1 transferable
-      to a mouse's configuration.
-
-NOTE: The below files should live in /etc/X11/xorg.conf.d/.
-
-
-* 10-keyboard.conf
-
-  The 10-keyboard.conf file is used to tell Xorg how it should setup the
-  keyboard and which device node it should interact with.
-
-  Section "InputDevice"
-      Identifier "keyboard0"
-      Option     "CoreKeyboard"
-      Option     "AutoServerLayout" "true"
-
-      # Use the libinput driver.
-      Driver     "libinput"
-
-      # This must point to the '/dev/input'
-      # entry of your touchpad or mouse.
-      Option     "Device" "/dev/input/event4"
-
-      # Change the values of these to match
-      # the detected layout of the command
-      # 'setxkbmap -query'.
-      Option     "XkbLayout" "us"
-      Option     "XkbModel"  "pc105"
-      Option     "XkbRules"  "evdev"
-  EndSection
-
-
-* 10-touchpad.conf
-
-  The 10-touchpad.conf file is used to tell Xorg how it should setup the
-  touchpad and which device node it should interact with.
-
-  Section "InputDevice"
-      Identifier "touchpad0"
-      Option     "CorePointer"
-      Option     "AutoServerLayout" "true"
-
-      # Use the libinput driver.
-      Driver     "libinput"
-
-      # This must point to the '/dev/input'
-      # entry of your touchpad or mouse.
-      Option     "Device" "/dev/input/event5"
-
-      # libinput options (optional).
-      Option     "ScrollMethod" "twofinger"
-      Option     "TappingDrag" "true"
-      Option     "Tapping" "true"
-  EndSection
-
-
 PURGING EUDEV
 ________________________________________________________________________________
 
 * Disable the udevd service
 
-  NOTE: From this point forward any device manager hotplugging functionality
-        will be unusable.
-
-  $ unlink /var/service/udevd
+  # unlink /var/service/udevd
 
 
 * Remove the eudev package
@@ -156,6 +35,11 @@ ________________________________________________________________________________
   $ kiss-revdepends eudev
   libinput/depends:eudev
   xorg-server/depends:eudev
+
+
+* Build libudev-zero
+
+  $ kiss b libudev-zero && kiss i libudev-zero
 
 
 * Rebuild all required packages
@@ -186,7 +70,35 @@ ________________________________________________________________________________
 
   Simply enable the `mdev` service.
 
-  ln -s /etc/sv/mdev/ /var/service
+  # ln -s /etc/sv/mdev/ /var/service
+
+
+* uevent helper (Alternate method)
+
+  Modify your KISS hook to install the uevent helper with libudev-zero:
+
+  +--------------------------------------------------------------------------+
+  |                                                                          |
+  |   case $TYPE in                                                          |  
+  |       post-build)                                                        |
+  |           case $PKG in                                                   |
+  |               libudev-zero)                                              |
+  |                   "${CC:-cc}" -o helper                                  |
+  |                   install -Dm755 helper "$DEST/usr/bin/uevent-helper"    |
+  |               ;;                                                         |
+  |           esac                                                           |
+  |                                                                          |
+  +--------------------------------------------------------------------------+
+
+  Enable CONFIG_UEVENT_HELPER in your kernel configuration and set
+  CONFIG_UEVENT_HELPER_PATH to /usr/bin/uevent-helper.
+
+  Alternatively, the uevent helper path can be set by the init system.
+
+  # echo "/bin/echo /usr/bin/uevent-helper <dir> > /proc/sys/kernel/hotplug"
+
+  Replace <dir> with the path where you want the uevent files to be stored, or
+  leave it empty to use the default path.
 
 
 * Other device managers
@@ -199,5 +111,5 @@ REBOOT
 ________________________________________________________________________________
 
 If all went well, you should now be using mdev as your device manager while
-retaining a fully working graphical environment. If input doesn't work under
-Xorg, refer to the Xorg log file for information.
+retaining a fully working graphical environment with hotplugging functionality.
+If input doesn't work under Xorg, refer to the Xorg log file for information.


### PR DESCRIPTION
Just needed a few minor modifications, not sure if we should still keep the static xorg configuration since its a PITA to get working (in my experience).